### PR TITLE
Fix missing dependency + setActivity in rewrite

### DIFF
--- a/js/Podbot.js
+++ b/js/Podbot.js
@@ -62,7 +62,7 @@ class Podbot {
 	_onReady() {
 		log.log(`Connected as ${this._client.user.username}#${this._client.user.discriminator} ${this._client.user.id}`);
 		if (this._config.game.length) {
-			this._client.user.setGame(this._config.game);
+			this._client.user.setActivity(this._config.game);
 		}
 	}
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "inquirer": "^5.1.0",
     "lodash.escaperegexp": "^4.1.2",
     "node-opus": "^0.2.7",
+    "sodium": "^2.0.3",
     "uws": "^9.14.0",
     "zlib-sync": "^0.1.4"
   }

--- a/package.json
+++ b/package.json
@@ -20,10 +20,11 @@
   "homepage": "https://github.com/Fiddlekins/podbot#readme",
   "dependencies": {
     "bufferutil": "^3.0.3",
-    "discord.js": "^11.3.0",
+    "discord.js": "discordjs/discord.js#11.3-dev",
     "erlpack": "^0.1.2",
     "fs-extra": "^5.0.0",
     "inquirer": "^5.1.0",
+    "libsodium-wrappers": "^0.7.3",
     "lodash.escaperegexp": "^4.1.2",
     "node-opus": "^0.2.7",
     "sodium": "^2.0.3",


### PR DESCRIPTION
- **Add missing `sodium` dependency; it was removed by accident in the rewrite. Fixes error:** EDIT: See next post as well.

```bash

9|podbot   | TypeError: secretbox.open is not a function
9|podbot   |     at VoiceReceiver.handlePacket (/home/vlexar/main/vlexar/podbot/podbot/node_modules/discord.js/src/client/voice/receiver/VoiceReceiver.js:150:26)
9|podbot   |     at Socket.VoiceReceiver._listener.msg (/home/vlexar/main/vlexar/podbot/podbot/node_modules/discord.js/src/client/voice/receiver/VoiceReceiver.js:57:14)
9|podbot   |     at Socket.emit (events.js:160:13)
9|podbot   |     at UDP.onMessage [as onmessage] (dgram.js:659:8)
```

- **Change `setGame` to `setActivity` to fix depreciation warning. Fixes:**

```bash
9|podbot   | (node:26298) DeprecationWarning: ClientUser#setGame: use ClientUser#setActivity instead
```

🙂 
