### PR TITLE
Trim whitespace from token environment variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,7 +130,7 @@ async function init() {
 		if (argv["env-config"]) {
 			config = {
 				podbot: {
-					token: process.env.POD_TOKEN,
+					token: process.env.POD_TOKEN.trim(),
 					podcastPath: process.env.POD_PODCAST_PATH,
 					controllers: {
 						roles: process.env.POD_ROLES.split(','),


### PR DESCRIPTION
 * Including whitespace or newlines in the bot token causes them to be added to the HTTP headers of the requests made to the Discord API, breaking the application.  This simply trims whitespace from the API token before using it.